### PR TITLE
Added chronograf_path setting that make it easier to reverse proxy this add-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Example add-on configuration:
     "ssl": true,
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
-    "ipv6": true
+    "ipv6": true,
+    "chronograf_path": "/",
 }
 ```
 
@@ -152,6 +153,10 @@ The private key file to use for SSL.
 ### Option: `ipv6`
 
 Set this option to `false` to disable IPv6 support.
+
+### Option: `chronograf_path`
+
+Set this option to something different from `/`, but that begins with a `/` to enable Chronograf's `basepath` option. It makes Chronograf much easier to use begin a reverse proxy. 
 
 ### Option: `i_like_to_be_pwned`
 

--- a/influxdb/config.json
+++ b/influxdb/config.json
@@ -33,7 +33,8 @@
     "ssl": true,
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
-    "ipv6": true
+    "ipv6": true,
+    "chronograf_path": "/"
   },
   "schema": {
     "log_level": "match(^(trace|debug|info|notice|warning|error|fatal)$)",
@@ -44,6 +45,7 @@
     "certfile": "str",
     "keyfile": "str",
     "ipv6": "bool",
+    "chronograf_path": "str",
     "i_like_to_be_pwned": "bool?",
     "leave_front_door_open": "bool?"
   },

--- a/influxdb/rootfs/etc/cont-init.d/11-nginx.sh
+++ b/influxdb/rootfs/etc/cont-init.d/11-nginx.sh
@@ -35,3 +35,17 @@ else
     password=$(hass.config.get 'password')
     htpasswd -bc /etc/nginx/.htpasswd "${username}" "${password}"
 fi
+
+if [[ $(hass.config.get 'chronograf_path') != "/" ]]
+then
+        sed -i 's/^##chronograf_path_SET//' /etc/nginx/nginx.conf
+        sed -i 's/^##chronograf_path_SET//' /etc/nginx/nginx-ssl.conf
+
+        export chronograf_path=$(echo $(hass.config.get 'chronograf_path') | sed 's|^/||' | sed 's|/|\\/|g' )
+        echo $chronograf_path
+        sed -i "s/##chronograf_path##/${chronograf_path}/g" /etc/nginx/nginx.conf
+        sed -i "s/##chronograf_path##/${chronograf_path}/g" /etc/nginx/nginx-ssl.conf
+else
+        sed -i 's/^##chronograf_path_NOTSET//' /etc/nginx/nginx.conf
+        sed -i 's/^##chronograf_path_NOTSET//' /etc/nginx/nginx-ssl.conf
+fi

--- a/influxdb/rootfs/etc/nginx/nginx-ssl.conf
+++ b/influxdb/rootfs/etc/nginx/nginx-ssl.conf
@@ -45,7 +45,15 @@ http {
         add_header X-XSS-Protection "1; mode=block";
         add_header X-Robots-Tag none;
 
-        location / {
+##chronograf_path_SETlocation /##chronograf_path## {
+##chronograf_path_SET    # Empty; this is just here to avoid redirecting for this location,
+##chronograf_path_SET    # though you might already have some config in a block like this.
+##chronograf_path_SET}
+
+location / {
+
+##chronograf_path_SET            rewrite ^/(.*)$ http://$host:$server_port/##chronograf_path## redirect;
+
             proxy_redirect off;
             proxy_pass http://chronograf;
 

--- a/influxdb/rootfs/etc/nginx/nginx.conf
+++ b/influxdb/rootfs/etc/nginx/nginx.conf
@@ -29,7 +29,12 @@ http {
         listen [::]:8888 default_server;
         root /dev/null;
 
-        location / {
+##chronograf_path_SETlocation / {
+##chronograf_path_SET    rewrite ^/(.*)$ http://$host:$server_port/##chronograf_path##/$1 redirect;
+##chronograf_path_SET}
+
+##chronograf_path_SETlocation /##chronograf_path##/ {
+##chronograf_path_NOTSETlocation / {
             proxy_redirect off;
             proxy_pass http://chronograf;
 

--- a/influxdb/rootfs/etc/services.d/chronograf/run
+++ b/influxdb/rootfs/etc/services.d/chronograf/run
@@ -27,6 +27,11 @@ options+=(--influxdb-username="chronograf")
 options+=(--influxdb-password="${HASSIO_TOKEN}")
 options+=(--kapacitor-url="http://localhost:9092")
 
+if [[ $(hass.config.get 'chronograf_path') != '/' ]]
+then
+	options+=(--basepath=$(hass.config.get 'chronograf_path'))
+fi
+
 # Find the matching Chronograph log level
 case "$(hass.string.lower "$(hass.config.get 'log_level')")" in
     all|trace|debug)


### PR DESCRIPTION
# Proposed Changes

> Added the parameter `chronograf_path` to the add-on, tweaked Nginx config to take care of it and used this parameter in Chronograf `run` script.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/