### PR TITLE
Limit supported machines

### DIFF
--- a/influxdb/config.json
+++ b/influxdb/config.json
@@ -12,6 +12,19 @@
     "armhf",
     "i386"
   ],
+  "machine": [
+    "intel-nuc",
+    "qemux86",
+    "qemux86-64",
+    "qemuarm",
+    "qemuarm-64",
+    "raspberrypi2",
+    "raspberrypi3",
+    "raspberrypi3-64",
+    "tinker",
+    "odroid-c2",
+    "odroid-xu"
+  ],
   "map": [
     "config:rw",
     "share:rw",


### PR DESCRIPTION
# Proposed Changes

Most ARM-based devices are supported, but a ARMv6 is not.
This PR changes the config.json to limit that.
Support for this was added to Hass.io in v132 (https://github.com/home-assistant/hassio/pull/720).

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/