### PR TITLE
🔨 Add environment variable support for InfluxDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ configuration as documented at:
 **Note**: _Changing these options can possibly cause issues with you instance.
 USE AT YOUR OWN RISK!_
 
+These are case sensitive.
+
 #### Sub-option: `name`
 
 The name of the environment variable to set which must start with `INFLUXDB_`

--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ Example add-on configuration:
     "reporting": true,
     "ssl": true,
     "certfile": "fullchain.pem",
-    "keyfile": "privkey.pem"
+    "keyfile": "privkey.pem",
+    "envvars": [
+      {
+        "name": "INFLUXDB_HTTP_LOG_ENABLED",
+        "value": "true"
+      }
+    ]
 }
 ```
 
@@ -118,6 +124,25 @@ The certificate file to use for SSL.
 The private key file to use for SSL.
 
 **Note**: _The file MUST be stored in `/ssl/`, which is the default for Hass.io_
+
+### Option: `envvars`
+
+This allows the setting of Environment Variables to control InfluxDB
+configuration as documented at:
+
+ <https://docs.influxdata.com/influxdb/v1.7/administration/config/#configuration-settings>
+
+**Note**: _Changing these options can possibly cause issues with you instance.
+USE AT YOUR OWN RISK!_
+
+#### Sub-option: `name`
+
+The name of the environment variable to set which must start with `INFLUXDB_`
+
+#### Sub-option: `value`
+
+The value of the environment variable to set, set the Influx documentation for
+full details.
 
 ### Option: `leave_front_door_open`
 

--- a/influxdb/config.json
+++ b/influxdb/config.json
@@ -50,7 +50,7 @@
     "keyfile": "str",
     "envvars": [
       {
-        "name": "match(^INFLUXDB_)",
+        "name": "match(^INFLUXDB_([A-Z0-9_])+$))",
         "value": "str"
       }
     ],

--- a/influxdb/config.json
+++ b/influxdb/config.json
@@ -38,7 +38,8 @@
     "reporting": true,
     "ssl": true,
     "certfile": "fullchain.pem",
-    "keyfile": "privkey.pem"
+    "keyfile": "privkey.pem",
+    "envvars": []
   },
   "schema": {
     "log_level": "match(^(trace|debug|info|notice|warning|error|fatal)$)?",
@@ -47,6 +48,12 @@
     "ssl": "bool",
     "certfile": "str",
     "keyfile": "str",
+    "envvars": [
+      {
+        "name": "match(^INFLUXDB_)",
+        "value": "str"
+      }
+    ],
     "leave_front_door_open": "bool?"
   }
 }

--- a/influxdb/rootfs/etc/services.d/influxdb/run
+++ b/influxdb/rootfs/etc/services.d/influxdb/run
@@ -3,6 +3,16 @@
 # Community Hass.io Add-ons: InfluxDB
 # Runs the InfluxDB Server
 # ==============================================================================
+declare name
+declare value
+
+for envvar in $(bashio::config 'envvars|keys'); do
+    name=$(bashio::config "envvars[${envvar}].name")
+    value=$(bashio::config "envvars[${envvar}].value")
+    bashio::log.debug "Setting Env Variable ${name} to ${value}"
+    export "${name}"="${value}"
+done
+
 bashio::log.info 'Starting the InfluxDB...'
 
 # Run InfluxDB

--- a/influxdb/rootfs/etc/services.d/influxdb/run
+++ b/influxdb/rootfs/etc/services.d/influxdb/run
@@ -10,7 +10,7 @@ for envvar in $(bashio::config 'envvars|keys'); do
     name=$(bashio::config "envvars[${envvar}].name")
     value=$(bashio::config "envvars[${envvar}].value")
     bashio::log.debug "Setting Env Variable ${name} to ${value}"
-    export "${name}"="${value}"
+    export "${name}=${value}"
 done
 
 bashio::log.info 'Starting the InfluxDB...'


### PR DESCRIPTION
# Proposed Changes

Add a new config option to allow setting Environment Variables for InfluxDB, which allows further configuration as per the Influx Docs.  The config file will always take precedence.

## Related Issues

Helps with #51 and #49 