### PR TITLE
update example host name

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Now we've got this in place, add the following snippet to your Home Assistant
 
 ```yaml
 influxdb:
-  host: a0d7b954-influxdb
+  host: localhost
   port: 8086
   database: homeassistant
   username: homeassistant


### PR DESCRIPTION
Proposing a change to the example HA config hostname. While I don't condone blindly cutting and pasting code, having an example that works without changing in a standard Hass.io install is probably wise.

