### PR TITLE
fix: switch from TSM to TSI to aleviate out of memory errors with indexing

### DIFF
--- a/influxdb/rootfs/etc/influxdb/influxdb.conf
+++ b/influxdb/rootfs/etc/influxdb/influxdb.conf
@@ -4,7 +4,7 @@ reporting-disabled = false
 
 [data]
   dir = "/data/influxdb/data"
-  engine = "tsm1"
+  index-version = "tsi1"
   wal-dir = "/data/influxdb/wal"
 
 [http]


### PR DESCRIPTION


# Proposed Changes

Switch from TSM (in memory only) indexing to the new TSI indexing. This is to support a larger number of time series without running into out of memory issues. See https://docs.influxdata.com/influxdb/v1.7/administration/upgrading/ as well as https://docs.influxdata.com/influxdb/v1.7/concepts/time-series-index/

## Related Issues

https://github.com/hassio-addons/addon-influxdb/issues/53


<blockquote><img src="https://www.influxdata.com/wp-content/uploads/Simple-Kubo.jpg" width="48" align="right"><div><strong><a href="https://docs.influxdata.com/"> Upgrading to InfluxDB 1.7.x | InfluxData Documentation</a></strong></div></blockquote>
<blockquote><img src="https://www.influxdata.com/wp-content/uploads/Simple-Kubo.jpg" width="48" align="right"><div><strong><a href="https://docs.influxdata.com/"> Time Series Index (TSI) overview | InfluxData Documentation</a></strong></div></blockquote>