### PR TITLE
Restore add-on Supervisor API access

### DIFF
--- a/influxdb/config.json
+++ b/influxdb/config.json
@@ -10,6 +10,7 @@
   "panel_icon": "mdi:chart-areaspline",
   "startup": "services",
   "homeassistant": "0.92.0b2",
+  "hassio_api": true,
   "arch": ["aarch64", "amd64", "armv7", "i386"],
   "init": false,
   "map": ["share:rw", "ssl"],


### PR DESCRIPTION
# Proposed Changes

Restore API access to the Supervisor. Part of the NGinx reverse proxy setup, rely on the API for information.
