### PR TITLE
Fix CI badges to show the right status

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ SOFTWARE.
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg
 [forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-influxdb/54491?u=frenck
 [frenck]: https://github.com/frenck
-[github-actions-shield]: https://github.com/hassio-addons/addon-example/workflows/CI/badge.svg
-[github-actions]: https://github.com/hassio-addons/addon-example/actions
+[github-actions-shield]: https://github.com/hassio-addons/addon-influxdb/workflows/CI/badge.svg
+[github-actions]: https://github.com/hassio-addons/addon-influxdb/actions
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
 [i386-shield]: https://img.shields.io/badge/i386-yes-green.svg


### PR DESCRIPTION
# Proposed Changes

The CI badge shown in the README was actually showing the CI status of the example add-on.

Brought you by me, an excellent copy and paster ☺️ 
