### PR TITLE
Remove obsolete webui from configuration

### DIFF
--- a/influxdb/config.json
+++ b/influxdb/config.json
@@ -4,7 +4,6 @@
   "slug": "influxdb",
   "description": "Scalable datastore for metrics, events, and real-time analytics",
   "url": "https://github.com/hassio-addons/addon-influxdb",
-  "webui": "[PROTO:ssl]://[HOST]:[PORT:80]",
   "ingress": true,
   "ingress_port": 1337,
   "panel_icon": "mdi:chart-areaspline",


### PR DESCRIPTION
# Proposed Changes

The `webui` option is obsolete, because this add-on provides Ingress access.
