### PR TITLE
Upgrade add-on base image to 4.1.2

### DIFF
--- a/influxdb/Dockerfile
+++ b/influxdb/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:4.0.0
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:4.1.2
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/influxdb/build.json
+++ b/influxdb/build.json
@@ -1,8 +1,8 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/hassio-addons/debian-base/aarch64:4.0.0",
-    "amd64": "ghcr.io/hassio-addons/debian-base/amd64:4.0.0",
-    "armv7": "ghcr.io/hassio-addons/debian-base/armv7:4.0.0",
-    "i386": "ghcr.io/hassio-addons/debian-base/i386:4.0.0"
+    "aarch64": "ghcr.io/hassio-addons/debian-base/aarch64:4.1.2",
+    "amd64": "ghcr.io/hassio-addons/debian-base/amd64:4.1.2",
+    "armv7": "ghcr.io/hassio-addons/debian-base/armv7:4.1.2",
+    "i386": "ghcr.io/hassio-addons/debian-base/i386:4.1.2"
   }
 }


### PR DESCRIPTION
# Proposed Changes

Upgrades the add-on image to 4.1.2, which solves an issue with the S6 Overlay