### PR TITLE
SSL Should be disabled by default

### DIFF
--- a/influxdb/config.json
+++ b/influxdb/config.json
@@ -25,9 +25,9 @@
   "options": {
     "auth": true,
     "reporting": true,
-    "ssl": true,
-    "certfile": "fullchain.pem",
-    "keyfile": "privkey.pem",
+    "ssl": false,
+    "certfile": "",
+    "keyfile": "",
     "envvars": []
   },
   "schema": {


### PR DESCRIPTION
# Proposed Changes
Most people who will be installing this through a supervised installation won't have setup SSL as that is in advanced option. SSL therefor should be disabled by default.
