### PR TITLE
Add note about env values to documentation

### DIFF
--- a/influxdb/DOCS.md
+++ b/influxdb/DOCS.md
@@ -108,7 +108,7 @@ The name of the environment variable to set which must start with `INFLUXDB_`
 #### Sub-option: `value`
 
 The value of the environment variable to set, set the Influx documentation for
-full details.
+full details. Values should always be entered as a string (even true/false values).
 
 ### Option: `leave_front_door_open`
 


### PR DESCRIPTION
Specified that environment variable values should always be entered in string format, even if the value is a boolean (true/false).

# Proposed Changes

Specified that environment variable values should always be entered in string format, even if the value is a boolean (true/false). 

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
