### PR TITLE
🔨 Disable chronograf telemetry

### DIFF
--- a/influxdb/rootfs/etc/services.d/chronograf/run
+++ b/influxdb/rootfs/etc/services.d/chronograf/run
@@ -62,5 +62,9 @@ fi
 ingress_entry=$(bashio::addon.ingress_entry)
 options+=(--basepath "${ingress_entry}")
 
+if bashio::config.false 'reporting'; then
+    options+=(--reporting-disabled)
+fi
+
 # Run Chronograf
 exec chronograf "${options[@]}"


### PR DESCRIPTION
# Proposed Changes

Chronograf has its own reporting/telemetry option 

https://docs.influxdata.com/chronograf/v1.8/administration/config-options/#--reporting-disabled---r

Adds the flag based on the reporting config item

## Related Issues

#145 #164 
