### PR TITLE
Update link to influxdb integration

### DIFF
--- a/influxdb/DOCS.md
+++ b/influxdb/DOCS.md
@@ -155,7 +155,7 @@ and using the Data Explorer.
 
 Full details of the Home Assistant integration can be found here:
 
-<https://www.home-assistant.io/components/influxdb/>
+<https://www.home-assistant.io/integrations/influxdb/>
 
 ## Known issues and limitations
 


### PR DESCRIPTION
Components were renamed to integrations and the path to integrations on
the website reflects this. Although the old URL still forwards there,
might as well change it for clarity.

# Proposed Changes

The commit message contains all the necessary details.

## Related Issues

Although contributing guidelines state

> When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before making a change.

I think this change is well simple enough to do without that.