### PR TITLE
Add port configuration for backup and restore

### DIFF
--- a/influxdb/config.yaml
+++ b/influxdb/config.yaml
@@ -24,9 +24,11 @@ map:
 ports:
   80/tcp: null
   8086/tcp: 8086
+  8088/tcp: 8088
 ports_description:
   80/tcp: Web interface (Not required for Ingress)
   8086/tcp: InfluxDB server
+  8088/tcp: RPC service for backup and restore
 auth_api: true
 options:
   auth: true


### PR DESCRIPTION
# Proposed Changes

Adds port 8088, which is the RPC service used for backing up and restoring InfluxDB.

closes #286 