### PR TITLE
Fix application of the “reporting” setting

### DIFF
--- a/influxdb/rootfs/etc/cont-init.d/influxdb.sh
+++ b/influxdb/rootfs/etc/cont-init.d/influxdb.sh
@@ -6,7 +6,7 @@
 
 # Configures authentication
 if bashio::config.true 'auth'; then
-    sed -i 's/auth-enabled=.*/auth-enabled=true/' /etc/influxdb/influxdb.conf
+    sed -i 's/\<auth-enabled\>.*/auth-enabled=true/' /etc/influxdb/influxdb.conf
 else
     bashio::log.warning "InfluxDB authentication protection is disabled!"
     bashio::log.warning "This is NOT recommended!!!"
@@ -14,6 +14,6 @@ fi
 
 # Configures usage reporting to InfluxDB
 if bashio::config.false 'reporting'; then
-    sed -i 's/reporting-disabled=.*/reporting-disabled=true/' /etc/influxdb/influxdb.conf
+    sed -i 's/\<reporting-disabled\>.*/reporting-disabled=true/' /etc/influxdb/influxdb.conf
     bashio::log.info "Reporting of usage stats to InfluxData is disabled."
 fi


### PR DESCRIPTION
Remove whitespace sensitivity of the sed code enforcing it; the default configuration file has spaces around the equals sign at the moment.

(Do the same to the application of the “auth” setting too.  It works at the moment as is, but this is good for future-proofing.)

# Proposed Changes

> Restore the correct propagation of the “reporting” add-on setting to the “reporting-disabled” InfluxDB conf file setting.

## Related Issues

> Right now, the propagation's broken due to how the default configuration line uses whitespace.