### PR TITLE
Add influxd_local_only configuration setting

### DIFF
--- a/influxdb/DOCS.md
+++ b/influxdb/DOCS.md
@@ -69,6 +69,12 @@ Enable or disable InfluxDB user authentication.
 
 **Note**: _Turning this off is NOT recommended!_
 
+### Option: `influxd_local_only`
+
+Restricts InfluxDB HTTP port to only loopback (localhost) connections.
+
+**Note**: _It's recommended to turn this on since SSL isn't in use now._
+
 ### Option: `reporting`
 
 This option allows you to disable the reporting of usage data to InfluxData.

--- a/influxdb/config.yaml
+++ b/influxdb/config.yaml
@@ -31,6 +31,7 @@ ports_description:
 auth_api: true
 options:
   auth: true
+  influxd_local_only: false
   reporting: true
   ssl: true
   certfile: fullchain.pem
@@ -39,6 +40,7 @@ options:
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   auth: bool
+  influxd_local_only: bool
   reporting: bool
   ssl: bool
   certfile: str

--- a/influxdb/rootfs/etc/cont-init.d/influxdb.sh
+++ b/influxdb/rootfs/etc/cont-init.d/influxdb.sh
@@ -17,3 +17,11 @@ if bashio::config.false 'reporting'; then
     sed -i 's/\<reporting-disabled\>.*/reporting-disabled=true/' /etc/influxdb/influxdb.conf
     bashio::log.info "Reporting of usage stats to InfluxData is disabled."
 fi
+
+# Disables external connectivity of InfluxDB
+if bashio::config.true 'influxd_local_only'; then
+    sed -i '/^\[http\]$/a\'$'\n''  bind-address = "127.0.0.1:8086"' /etc/influxdb/influxdb.conf
+else
+    bashio::log.warning 'External network connections to InfluxDB are allowed.'
+    bashio::log.warning 'Given that no SSL is used, this may be a concern.'
+fi


### PR DESCRIPTION
Disables non-localhost connectivity of the InfluxDB HTTP port.

# Proposed Changes

> Permit restricting the usage of InfluxDB to the HA host alone.

## Related Issues

> Right now, the HTTP port of InfluxDB is open to connections incoming from any reachable networks, which may be undesirable in some networking environments.