### PR TITLE
Bump Kapacitor version from 1.5.9-1 to 1.6.6

### DIFF
--- a/influxdb/Dockerfile
+++ b/influxdb/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG BUILD_ARCH=amd64
 ARG INFLUXDB_VERSION="1.8.10"
 ARG CHRONOGRAF_VERSION="1.10.2"
-ARG KAPACITOR_VERSION="1.5.9-1"
+ARG KAPACITOR_VERSION="1.6.6"
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
# Proposed Changes

> Bump Kapacitor version from 1.5.9-1 to 1.6.6, so Flux Tasks is available. We could as well bump it to 1.7.x, but I see that this Dockerfile is conservative. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated an internal support component to a newer release, enhancing the build process and overall stability. End users should experience the same functionality with potential under-the-hood performance benefits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->