### PR TITLE
Expose Kapacitor API

### DIFF
--- a/influxdb/config.yaml
+++ b/influxdb/config.yaml
@@ -24,10 +24,12 @@ ports:
   80/tcp: null
   8086/tcp: 8086
   8088/tcp: 8088
+  9092/tcp: 9092
 ports_description:
   80/tcp: Web interface (Not required for Ingress)
   8086/tcp: InfluxDB server
   8088/tcp: RPC service for backup and restore
+  9092/tcp: Kapacitor HTTP API
 auth_api: true
 options:
   auth: true


### PR DESCRIPTION
Exposes Chronograf and Kapacitor components of container

# Proposed Changes

- Expose [Kapacitor HTTP API](https://docs.influxdata.com/kapacitor/v1/working/api/)

Allows use of the kapacitor instance within the container. 

# Use Case

- Ability to create/manage [tasks](https://docs.influxdata.com/kapacitor/v1/working/api/#define-or-update-a-task) from outside of home assistant, which can be used for example to forward data to an external influxdb instance. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated InfluxDB configuration to include port 9092 mapping and description for the Kapacitor HTTP API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->