### PR TITLE
Raise the limit of open files to 65535

### DIFF
--- a/influxdb/config.yaml
+++ b/influxdb/config.yaml
@@ -29,6 +29,8 @@ ports_description:
   8086/tcp: InfluxDB server
   8088/tcp: RPC service for backup and restore
 auth_api: true
+ulimits:
+  nofile: 65535
 options:
   auth: true
   reporting: true


### PR DESCRIPTION
# Proposed Changes

InfluxDB may need to use more than the default (since HAOS 16.0) 1024 file descriptors. Use the add-on config option to raise it to 65535 files.

## Related Issues

- Fixes #383
- Closes #387

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated InfluxDB configuration to increase file descriptor limits for enhanced system capacity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->