### PR TITLE
Add Optional User Configurable File Handler Soft Limit

### DIFF
--- a/influxdb/DOCS.md
+++ b/influxdb/DOCS.md
@@ -38,7 +38,7 @@ reporting: true
 ssl: true
 certfile: fullchain.pem
 keyfile: privkey.pem
-nofile: 65536
+nofile_soft_limit: 65536
 envvars:
   - name: INFLUXDB_HTTP_LOG_ENABLED
     value: "true"

--- a/influxdb/DOCS.md
+++ b/influxdb/DOCS.md
@@ -101,7 +101,7 @@ The limit for the number of open files for the InfluxDB process.  If left empty
 or 0, the limit will be the default soft limit of the container.
 
 If you are seeing errors in the log like `too many open files` try increasing
-this value. The default value in Home Assistant OS is 1024 and the maximum.
+this value. The default value in Home Assistant OS is 1024 and the maximum
 value is 524,288.
 
 ### Option: `envvars`

--- a/influxdb/DOCS.md
+++ b/influxdb/DOCS.md
@@ -38,6 +38,7 @@ reporting: true
 ssl: true
 certfile: fullchain.pem
 keyfile: privkey.pem
+nofile: 65536
 envvars:
   - name: INFLUXDB_HTTP_LOG_ENABLED
     value: "true"
@@ -93,6 +94,15 @@ The certificate file to use for SSL.
 The private key file to use for SSL.
 
 **Note**: _The file MUST be stored in `/ssl/`, which is the default_
+
+### Option: `nofile_soft_limit`
+
+The limit for the number of open files for the InfluxDB process.  If left empty
+or 0, the limit will be the default soft limit of the container.
+
+If you are seeing errors in the log like `too many open files` try increasing
+this value. The default value in Home Assistant OS is 1024 and the maximum.
+value is 524,288.
 
 ### Option: `envvars`
 

--- a/influxdb/config.yaml
+++ b/influxdb/config.yaml
@@ -43,6 +43,7 @@ schema:
   ssl: bool
   certfile: str
   keyfile: str
+  nofile_soft_limit: int?
   envvars:
     - name: match(^INFLUXDB_([A-Z0-9_])+$)
       value: str

--- a/influxdb/rootfs/etc/services.d/influxdb/run
+++ b/influxdb/rootfs/etc/services.d/influxdb/run
@@ -5,6 +5,8 @@
 # ==============================================================================
 declare name
 declare value
+declare nofile_soft_limit
+declare nofile_hard_limit
 
 for envvar in $(bashio::config 'envvars|keys'); do
     name=$(bashio::config "envvars[${envvar}].name")
@@ -12,6 +14,27 @@ for envvar in $(bashio::config 'envvars|keys'); do
     bashio::log.debug "Setting Env Variable ${name} to ${value}"
     export "${name}=${value}"
 done
+
+# Set nofile soft limit if configured
+nofile_soft_limit=$(bashio::config 'nofile_soft_limit')
+if [[ -n "${nofile_soft_limit}" && "${nofile_soft_limit}" != "null" && "${nofile_soft_limit}" != "0" ]]; then
+    if [[ "${nofile_soft_limit}" =~ ^[0-9]+$ ]] && (( nofile_soft_limit > 0 )); then
+        nofile_hard_limit=$(ulimit -H -n 2>/dev/null || true)
+        if [[ -n "${nofile_hard_limit}" && "${nofile_hard_limit}" != "unlimited" ]]; then
+            if [[ "${nofile_hard_limit}" =~ ^[0-9]+$ ]] && (( nofile_soft_limit > nofile_hard_limit )); then
+                bashio::log.warning "Requested nofile soft limit ${nofile_soft_limit} exceeds hard limit ${nofile_hard_limit}; clamping to ${nofile_hard_limit}"
+                nofile_soft_limit="${nofile_hard_limit}"
+            fi
+        fi
+
+        bashio::log.info "Setting nofile soft limit to ${nofile_soft_limit}"
+        if ! ulimit -S -n "${nofile_soft_limit}"; then
+            bashio::log.warning "Failed to set nofile soft limit to ${nofile_soft_limit}"
+        fi
+    else
+        bashio::log.warning "Invalid nofile soft limit value '${nofile_soft_limit}'; expected a positive integer"
+    fi
+fi
 
 bashio::log.info 'Starting the InfluxDB...'
 


### PR DESCRIPTION
# Proposed Changes

This adds a user configurable option for the file handler soft limit.  As discussed in hassio-addons/addon-influxdb#383 the default soft limit of 1024 file handlers introduced in HAOS 16 is too low for some users.  This results in a constant barrage of `too many open files` errors and a lot of CPU usage.

InfluxDB itself doesn't set or request any changes to the limits on the number of file handlers.  Nor do they provide any guidance on what the expectations should be.  Best I can find are forum comments [here](https://community.influxdata.com/t/too-many-open-files/3197) and [here](https://community.influxdata.com/t/influxdb-wont-start-failed-to-connect-to-streaming-server/18301/4) suggest anything from 500,000 to 65,536 are used by users.  

The config option is also "hidden" in that the user has to click `Show unused optional configuration options` in order to see the option.

By default, the option is unset and defaults to whatever the container has set, I believe 1024 for HAOS users.

I added safety checks to ensure that the requested soft limit is below the hard limit, and provided log messages to the user.

I was personally affected by this error.  I tested this by leaving the soft limits undefined, which resulted in the same error appearing.  When I changed the limit to 65536, the error went away.  I also tested setting the soft limit to an absurd number and the safety checks limited it to the HAOS maximum.

I am happy to make whatever suggested changes are required.  

For reference, I considered using the available addon container config as documented [here](https://developers.home-assistant.io/docs/add-ons/configuration) such as:
```yaml
ulimits:
  nofile:
    soft: 65536
```
However this would have affected all users and it seems like many are not affected by this issue.

Of course if the hard limit of 524,288 proves to be too low for anyone, then we would need to adjust the hard limit in the configuration.  But that seems unlikely.

## Related Issues

Fixes hassio-addons/addon-influxdb#383

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable file-descriptor soft limit that is validated at startup, clamped to the system hard limit, and logs a warning for invalid values.

* **Documentation**
  * Updated docs and examples to describe the new file limit configuration, default behavior, and allowed range.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->